### PR TITLE
Work in Progress: Fix principal attributes for rest protocol with mfa-gauth

### DIFF
--- a/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/GoogleAuthenticatorAuthenticationHandler.java
+++ b/support/cas-server-support-gauth-core/src/main/java/org/apereo/cas/gauth/GoogleAuthenticatorAuthenticationHandler.java
@@ -65,10 +65,11 @@ public class GoogleAuthenticatorAuthenticationHandler extends AbstractPreAndPost
         val validatedToken = validator.validate(authentication, tokenCredential);
         if (validatedToken != null) {
             val principal = authentication.getPrincipal().getId();
+            val attributes = authentication.getPrincipal().getAttributes();
             LOGGER.debug("Validated OTP token [{}] successfully for [{}]", validatedToken, principal);
             validator.store(validatedToken);
             LOGGER.debug("Creating authentication result and building principal for [{}]", principal);
-            return createHandlerResult(tokenCredential, this.principalFactory.createPrincipal(principal));
+            return createHandlerResult(tokenCredential, this.principalFactory.createPrincipal(principal, attributes));
         }
         LOGGER.warn("Authorization of OTP token [{}] has failed", credential);
         throw new FailedLoginException("Failed to authenticate code " + credential);


### PR DESCRIPTION
When using CAS REST Protocol with  mfa-gauth, in the final principal all resolved authentication attributes are lost.



